### PR TITLE
Update NetStandard dependencies

### DIFF
--- a/src/Polly.Caching.MemoryCache.nuspec
+++ b/src/Polly.Caching.MemoryCache.nuspec
@@ -34,6 +34,7 @@
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="Polly" version="5.4.0" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="1.1.2" />
       </group>
       <group targetFramework="net40">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />


### PR DESCRIPTION
State Microsoft.Extensions.Caching.Memory as an explicit dependency, for the NetStandard package